### PR TITLE
fixed warning C4828

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 /wiresock_service/obj/x86/Release/.NETFramework,Version=v4.7.2.AssemblyAttributes.cs
 ProxiFyre/bin
 ProxiFyre/obj
+.vs/
+/packages/

--- a/netlib/src/pcap/pcap.h
+++ b/netlib/src/pcap/pcap.h
@@ -1,4 +1,4 @@
-// ReSharper disable CppInconsistentNaming
+ï»¿// ReSharper disable CppInconsistentNaming
 #pragma once
 
 namespace pcap
@@ -158,10 +158,10 @@ namespace pcap
         LINKTYPE_STANAG_5066_D_PDU = 237,
         /// <summary>Linux netlink NETLINK NFLOG socket log messages</summary>
         LINKTYPE_NFLOG = 239,
-        /// <summary>Pseudo-header for Hilscher Gesellschaft für Systemautomation mbH netANALYZER devices,
+        /// <summary>Pseudo-header for Hilscher Gesellschaft fÃ¼r Systemautomation mbH netANALYZER devices,
         /// followed by an Ethernet frame, beginning with the MAC header and ending with the FCS</summary>
         LINKTYPE_NETANALYZER = 240,
-        /// <summary>Pseudo-header for Hilscher Gesellschaft für Systemautomation mbH netANALYZER devices,
+        /// <summary>Pseudo-header for Hilscher Gesellschaft fÃ¼r Systemautomation mbH netANALYZER devices,
         /// followed by an Ethernet frame, beginning with the preamble, SFD, and MAC header, and ending
         /// with the FCS</summary>
         LINKTYPE_NETANALYZER_TRANSPARENT = 241,


### PR DESCRIPTION
proxifyre\netlib\src\pcap\pcap.h(1,1): warning C4828: The file contains a character starting at offset 0x209a that is illegal in the current source character set (codepage 65001).